### PR TITLE
Fix image links in TWIR5

### DIFF
--- a/news/this-week-in-redox-5/index.html
+++ b/news/this-week-in-redox-5/index.html
@@ -81,14 +81,14 @@
 
 <p>;)</p>
 
-<p><img src="https://raw.githubusercontent.com/redox-os/redox/master/img/fun/fancy.jpg" alt="Cellphone" />
+<p><img src="https://raw.githubusercontent.com/redox-os/redox/master/img/fun/fancy.png" alt="Cellphone" />
 </p>
 
 <p>Since the changes are mostly internal, we don&rsquo;t got a lot of new fancy screenshots except for Sodium:</p>
 
 <p>Sodium has syntax highlighting and a lot of new features:</p>
 
-<p><img src="https://raw.githubusercontent.com/redox-os/redox/master/img/fun/Sodium_v1.jpg" alt="Sodium" />
+<p><img src="https://raw.githubusercontent.com/redox-os/redox/master/img/screenshots/Sodium_v1.png" alt="Sodium" />
 </p>
 
 <h1 id="what-s-next:6e3f200f75687b33625364256d63593e">What&rsquo;s next?</h1>


### PR DESCRIPTION
The first linked image had a .jpg extension while the one in the repo is a .png .
The second image pointed to the `img/fun/` folder whereas the actual image is in `img/screenshots/` .

It wouldn't necessarily be a bad idea to migrate these images over to this site so changes to the master branch in redox won't invalidate pieces of this site, but that is a decision that someone else who is more involved would likely need to make.  In the meantime this will make things work.